### PR TITLE
No need to send config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # docker-container-updater
 Stuff to auto-update docker container on server
 
-`docker run --privileged --restart=always -itd -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/.docker/config.json:/home/nct-at/.docker/config.json docker-container-updater`
+`docker run --privileged --restart=always -itd -v /var/run/docker.sock:/var/run/docker.sock docker-container-updater`


### PR DESCRIPTION
Before it used to able to access to `onlyoffice/4testing-documentserver-integration` docker hub repo, but now this is public repo