### PR TITLE
onlyofficetestingrobot/nct-at-testing-node has no ~/.rvm/scripts/rvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN sudo apt-get update && \
 RUN sudo usermod -aG docker nct-at
 COPY . /home/nct-at/docker-container-updater
 WORKDIR /home/nct-at/docker-container-updater
-CMD bash -c "source ~/.rvm/scripts/rvm && ruby main.rb"
+CMD bash -c "ruby main.rb"


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/testing-shared/pull/474