### PR TITLE
onlyofficetestingrobot/nct-at-testing-node is debian based now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ RUN sudo apt-get update && \
             ca-certificates \
             curl \
             software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add -
 RUN sudo add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
-            stable"
+         "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+         $(lsb_release -cs) \
+         stable"
 RUN sudo apt-get update && \
     sudo apt-get -y install docker-ce
 RUN sudo usermod -aG docker nct-at


### PR DESCRIPTION
So change docker installation accordingly
Since:
https://github.com/ONLYOFFICE/testing-shared/pull/461