### PR TITLE
Start all supervisor processes

### DIFF
--- a/lib/docker_container_updater/updater.rb
+++ b/lib/docker_container_updater/updater.rb
@@ -31,7 +31,7 @@ module DockerContainerUpdater
       p 'Sleeping for wait for container to start'
       sleep 30
       `docker exec #{@container_name} \
-       sudo supervisorctl start onlyoffice-documentserver:example`
+       supervisorctl start all`
       p 'Sleeping for wait for font generating'
       sleep 60
     end


### PR DESCRIPTION
Naming of example was changed in 5.2 (AFAIR)
And better start any process, not process by name