### PR TITLE
Do not update `SharedFunctional` repo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,3 +5,4 @@
 ### New features
 
 * Show more version info in logs
+* Do not update `SharedFunctional` repo

--- a/lib/docker_container_updater/updater.rb
+++ b/lib/docker_container_updater/updater.rb
@@ -37,8 +37,6 @@ module DockerContainerUpdater
     end
 
     def run_tests
-      `cd ~/RubymineProjects/SharedFunctional; \
-       git reset --hard; git pull --prune`
       `cd ~/RubymineProjects/OnlineDocuments; \
        git reset --hard; git checkout develop; git pull --prune`
       `cd ~/RubymineProjects/OnlineDocuments && bundle update`


### PR DESCRIPTION
It was remove from image at:
https://github.com/ONLYOFFICE/testing-shared/commit/464f466eefcfff7c63684a76617bcd76663d45c6