### PR TITLE
Use default branch for OnlineDocuments repo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,3 +6,4 @@
 
 * Show more version info in logs
 * Do not update `SharedFunctional` repo
+* Use default branch for `OnlineDocuments` repo

--- a/lib/docker_container_updater/updater.rb
+++ b/lib/docker_container_updater/updater.rb
@@ -38,7 +38,7 @@ module DockerContainerUpdater
 
     def run_tests
       `cd ~/RubymineProjects/OnlineDocuments; \
-       git reset --hard; git checkout develop; git pull --prune`
+       git pull --prune`
       `cd ~/RubymineProjects/OnlineDocuments && bundle update`
       system('cd ~/RubymineProjects/OnlineDocuments && '\
              "SPEC_SERVER_IP=#{test_example_url} "\


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/testing-shared/commit/919751da4b50ff8a101953131f7eb141bfae3ad1
There was no develop in `testing-documents` project